### PR TITLE
Make invocation of mktemp compatible with busybox

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -31,8 +31,8 @@ if [ $? -eq 0 ];then
 	add_err "wifish should fail with WIFISH_DEFAULT as 'foo'"
 fi
 
-tfile=$(mktemp /tmp/$$.XXX.parsed)
-efile=$(mktemp /tmp/$$.XXX.parsed.err)
+tfile=$(mktemp /tmp/$$.parsed.XXXXXX)
+efile=$(mktemp /tmp/$$.parsed.err.XXXXXX)
 trap 'rm -f $tfile' INT TERM EXIT
 trap 'rm -f $efile' INT TERM EXIT
 WIFISH_DEFAULT=list AWK_LOCATION=./awk _IN_TEST=true ./wifish >$tfile 2>$efile

--- a/wifish
+++ b/wifish
@@ -73,7 +73,7 @@ scan_results() { # {{{ # Scans for APs or shows scanned results. Writes to $stem
 
 	echo " * Scanning For APs ..." >&2
         # Get the data
-	stemp=$(mktemp /tmp/$$.XXXX.menu)
+	stemp=$(mktemp /tmp/$$.menu.XXXXXX)
 	trap 'rm -f $stemp' INT TERM EXIT
 	if [ -n "$_IN_TEST" ];then # {{{ # Test/Mock mode
                 cat data/wscan.txt > $stemp # }}}


### PR DESCRIPTION
Alpine Linux uses Busybox as userland and their mktemp utility [requires](https://github.com/mozilla-b2g/busybox/blob/master/debianutils/mktemp.c#L38) XXXXXX at the end.

Based on [2](https://gitlab.com/maxice8/abuilds/blob/master/wifish/fix-busybox-mktemp.patch) [patches](https://gitlab.com/maxice8/abuilds/blob/master/wifish/fix-busybox-mktemp-test.patch) i used to keep during my short time on Alpine Linux.